### PR TITLE
setup() now waits for Serial Monitor to start

### DIFF
--- a/examples/Grove_Starter_Kit/Grove_Light_Sensor/Grove_Light_Sensor.ino
+++ b/examples/Grove_Starter_Kit/Grove_Light_Sensor/Grove_Light_Sensor.ino
@@ -6,6 +6,9 @@ const int pinLight = A0;
 void setup()
 {
     Serial.begin(9600);
+    //wait for serial monitor to start
+    while(!Serial)
+        delay(100);
 }
 
 void loop()


### PR DESCRIPTION
Wait for Serial Monitor to start before completing setup()

Linkit One HDK FAQ (https://labs.mediatek.com/forums/posts/list/61.page) says the setup() should be similar to Arduino Leonardo